### PR TITLE
Skip HTTPS test for local URL in channels attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.11
+    - image: circleci/node:8.11-stretch
 
 workflows:
   version: 2

--- a/src/ScopeRequest.js
+++ b/src/ScopeRequest.js
@@ -28,6 +28,9 @@ const VALID_OPERATORS = [
   '$exists',
 ];
 
+const isLocal = url => (url.match('(http://|https://)?(localhost|127.0.0.*)') !== null);
+
+
 /**
  * Class for generating Scope Requests
  */
@@ -143,11 +146,14 @@ class ScopeRequest {
       throw new Error('eventsURL is required');
     }
 
-    if (!_.startsWith(channelsConfig.eventsURL, 'https')) {
+    if (!isLocal(channelsConfig.eventsURL)
+        && !_.startsWith(channelsConfig.eventsURL, 'https')) {
       throw new Error('only HTTPS is supported for eventsURL');
     }
 
-    if (channelsConfig.payloadURL && !_.startsWith(channelsConfig.payloadURL, 'https')) {
+    if (channelsConfig.payloadURL
+        && !isLocal(channelsConfig.payloadURL)
+        && !_.startsWith(channelsConfig.payloadURL, 'https')) {
       throw new Error('only HTTPS is supported for payloadURL');
     }
 

--- a/test/unit/ScopeRequest.test.js
+++ b/test/unit/ScopeRequest.test.js
@@ -17,8 +17,8 @@ const config = {
     secondaryColor: 'FFFFFF',
   },
   channels: {
-    baseEventsURL: 'https://localhost/sr/events',
-    basePayloadURL: 'https://localhost/sr/payload',
+    baseEventsURL: 'https://example.com/sr/events',
+    basePayloadURL: 'https://example.com/sr/payload',
   },
 };
 
@@ -98,6 +98,30 @@ describe('DSR Factory Tests', () => {
 
   it('Should succeed validation of an string identifier for credential items on a DSR', () => {
     const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1']);
+    const isValid = ScopeRequest.validateCredentialItems(dsr.credentialItems);
+    expect(isValid).toBeTruthy();
+  });
+
+  it('Should skip https test for local url in payloadUrl or eventsUrl and succeed validation', () => {
+    let dsr;
+    expect(() => {
+      dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
+        eventsURL: 'http://localhost/',
+        payloadURL: 'http://127.0.0.1/'
+      });
+    }).not.toThrow('only HTTPS is supported for payloadURL');
+    const isValid = ScopeRequest.validateCredentialItems(dsr.credentialItems);
+    expect(isValid).toBeTruthy();
+  });
+
+  it('Should skip https test for local url in ', () => {
+    let dsr;
+    expect(() => {
+      dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
+        eventsURL: 'https://localhost/',
+        payloadURL: 'http://127.0.0.1/'
+      });
+    }).not.toThrow('only HTTPS is supported for payloadURL');
     const isValid = ScopeRequest.validateCredentialItems(dsr.credentialItems);
     expect(isValid).toBeTruthy();
   });
@@ -238,21 +262,21 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the config file with eventsURL without https', () => {
     expect(() => {
       // eslint-disable-next-line no-unused-vars
-      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'http://localhost/' });
+      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'http://example.com/' });
     }).toThrow('only HTTPS is supported for eventsURL');
   });
 
   it('Should fail validation while mocking the config file with payloadURL without https', () => {
     expect(() => {
       // eslint-disable-next-line no-unused-vars
-      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://localhost/', payloadURL: 'http://localhost/' });
+      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://example.com/', payloadURL: 'http://example.com/' });
     }).toThrow('only HTTPS is supported for payloadURL');
   });
 
   it('Should fail validation while mocking the appConfig without id', () => {
     expect(() => {
       // eslint-disable-next-line no-unused-vars
-      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://localhost/', payloadURL: 'https://localhost/' }, {});
+      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://example.com/', payloadURL: 'https://example.com/' }, {});
     }).toThrow('app.id is required');
   });
 
@@ -261,7 +285,7 @@ describe('DSR Factory Tests', () => {
       const appConfig = { id: 'test' };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig);
     }).toThrow('app.name is required');
   });
@@ -270,16 +294,16 @@ describe('DSR Factory Tests', () => {
     expect(() => {
       const appConfig = { id: 'test', name: 'test' };
       // eslint-disable-next-line no-unused-vars
-      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://localhost/', payloadURL: 'https://localhost/' }, appConfig);
+      const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], { eventsURL: 'https://example.com/', payloadURL: 'https://example.com/' }, appConfig);
     }).toThrow('app.logo is required');
   });
 
   it('Should fail validation while mocking the appConfig without logo https', () => {
     expect(() => {
-      const appConfig = { id: 'test', name: 'test', logo: 'http://localhost/' };
+      const appConfig = { id: 'test', name: 'test', logo: 'http://example.com/' };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig);
     }).toThrow('only HTTPS is supported for app.logo');
   });
@@ -287,11 +311,11 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the appConfig without description', () => {
     expect(() => {
       const appConfig = {
-        id: 'test', name: 'test', logo: 'https://localhost/', primaryColor: 'FFF',
+        id: 'test', name: 'test', logo: 'https://example.com/', primaryColor: 'FFF',
       };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig);
     }).toThrow('app.description is required');
   });
@@ -299,11 +323,11 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the appConfig without primaryColor', () => {
     expect(() => {
       const appConfig = {
-        id: 'test', name: 'test', logo: 'https://localhost/', description: 'test',
+        id: 'test', name: 'test', logo: 'https://example.com/', description: 'test',
       };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig);
     }).toThrow('app.primaryColor is required');
   });
@@ -311,11 +335,11 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the appConfig without secondaryColor', () => {
     expect(() => {
       const appConfig = {
-        id: 'test', name: 'test', logo: 'https://localhost/', primaryColor: 'FFF', description: 'test',
+        id: 'test', name: 'test', logo: 'https://example.com/', primaryColor: 'FFF', description: 'test',
       };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig);
     }).toThrow('app.secondaryColor is required');
   });
@@ -323,12 +347,12 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the appConfig without partnerConfig id', () => {
     expect(() => {
       const appConfig = {
-        id: 'test', name: 'test', logo: 'https://localhost/', primaryColor: 'FFF', secondaryColor: 'FFF', description: 'test',
+        id: 'test', name: 'test', logo: 'https://example.com/', primaryColor: 'FFF', secondaryColor: 'FFF', description: 'test',
       };
       const partnerConfig = {};
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig, partnerConfig);
     }).toThrow('partner.id is required');
   });
@@ -336,14 +360,14 @@ describe('DSR Factory Tests', () => {
   it('Should fail validation while mocking the appConfig without partnerConfig signingKeys', () => {
     expect(() => {
       const appConfig = {
-        id: 'test', name: 'test', logo: 'https://localhost/', primaryColor: 'FFF', secondaryColor: 'FFF', description: 'test',
+        id: 'test', name: 'test', logo: 'https://example.com/', primaryColor: 'FFF', secondaryColor: 'FFF', description: 'test',
       };
       const partnerConfig = {
         id: 'test',
       };
       // eslint-disable-next-line no-unused-vars
       const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+        eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
       }, appConfig, partnerConfig);
     }).toThrow('Partner public and private signing keys are required');
   });
@@ -359,7 +383,7 @@ describe('DSR Factory Tests', () => {
     const appConfig = {
       id: 'test',
       name: 'test',
-      logo: 'https://localhost/',
+      logo: 'https://example.com/',
       primaryColor: 'FFF',
       secondaryColor: 'FFF',
       description: 'test',
@@ -373,7 +397,7 @@ describe('DSR Factory Tests', () => {
     };
     // eslint-disable-next-line no-unused-vars
     const dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-      eventsURL: 'https://localhost/', payloadURL: 'https://localhost/',
+      eventsURL: 'https://example.com/', payloadURL: 'https://example.com/',
     }, appConfig, partnerConfig);
     expect(dsr.requesterInfo.requesterId).toBe(partnerConfig.id);
   });
@@ -612,8 +636,8 @@ describe('DSR Request Utils', () => {
     const dsr = new ScopeRequest(
       requestId, 'credential-cvc:IDVaaS-v1',
       {
-        eventsURL: `https://localhost/event/${requestId}`,
-        payloadURL: `https://localhost/payload/${requestId}`,
+        eventsURL: `https://example.com/event/${requestId}`,
+        payloadURL: `https://example.com/payload/${requestId}`,
       },
       {
         id: 'TestPartnerApp',

--- a/test/unit/ScopeRequest.test.js
+++ b/test/unit/ScopeRequest.test.js
@@ -114,18 +114,6 @@ describe('DSR Factory Tests', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('Should skip https test for local url in ', () => {
-    let dsr;
-    expect(() => {
-      dsr = new ScopeRequest('abcd', ['credential-cvc:Identity-v1'], {
-        eventsURL: 'https://localhost/',
-        payloadURL: 'http://127.0.0.1/'
-      });
-    }).not.toThrow('only HTTPS is supported for payloadURL');
-    const isValid = ScopeRequest.validateCredentialItems(dsr.credentialItems);
-    expect(isValid).toBeTruthy();
-  });
-
   it('Should fail validation of an string identifier for credential items on a DSR', () => {
     expect(() => {
       const dsr = new ScopeRequest('abcd', [{}]);


### PR DESCRIPTION
Skip HTTPs verification for `eventsURL` and `payloadURL` attributes when a local URL is being specified.

The following pattern defines a local URL: `(http://|https://)?(localhost|127.0.0.*)`.

This change should make it easier to test a local flow.
