### PR TITLE
Update sjcl dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.11
+    - image: circleci/node:8.11-stretch
 
 workflows:
   version: 2
@@ -90,7 +90,7 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
-      - run: sudo apt-get update && sudo apt-get install default-jre
+      - run: sudo apt-get update
       - run: sudo npm install -g npm
       - run: npm ci
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -157,9 +157,7 @@ return `true` is the body is valid
 
 - [npm](https://www.npmjs.com/)
 - [Node.js](https://nodejs.org/en/)
-- *Java RE* *
 
-\* The *sjcl* library with ECC support will be built after the dependencies installation (see *postinstall* script in *package.json*). The build process of *sjcl* library requires the *Java RE* to be installed (for more details, please, refer to https://github.com/bitwiseshiftleft/sjcl/wiki/Getting-Started).
 
 ### Installation instructions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@identity.com/dsr-js",
+  "name": "@identity.com/dsr",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -219,7 +219,7 @@
         "@identity.com/uca": "1.0.0-rc.1",
         "ajv": "^6.6.2",
         "babel-runtime": "^6.26.0",
-        "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#bcash330",
+        "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#92c602567bd62dd1b41b717cc7d977c015104f1c",
         "bluebird": "^3.5.1",
         "bottlejs": "^1.7.1",
         "bson": "^3.0.0",
@@ -1629,7 +1629,7 @@
     "base-x": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
-      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "integrity": "sha1-062lmv7QW5IatYHsMRLmREugeVo=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1645,7 +1645,7 @@
     "bech32": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-0.0.3.tgz",
-      "integrity": "sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg=="
+      "integrity": "sha1-c2dHxKZTHF2JN9BABJjeMOk7L5w="
     },
     "big.js": {
       "version": "5.2.2",
@@ -1676,7 +1676,7 @@
     "bitcoin-ops": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+      "integrity": "sha1-5F3mIDmOIv1MpgI95Dl0/0IkAng="
     },
     "bitcoinjs-lib": {
       "version": "git+https://github.com/dabura667/bitcoinjs-lib.git#92c602567bd62dd1b41b717cc7d977c015104f1c",
@@ -1702,7 +1702,7 @@
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
     },
     "bootstrap": {
       "version": "4.3.1",
@@ -1779,7 +1779,7 @@
     "bs58check": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "integrity": "sha1-U7AYKRIo2CpaoI59eW/a/aVK6/w=",
       "requires": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -1798,7 +1798,7 @@
     "bson": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-3.0.2.tgz",
-      "integrity": "sha512-HrDzr7y/ZkgyEVancPVDmfbaD8j81GzSNr6h6yUd/yZfavkrlrqI8aUZMCHrhyMoCW2/I+vEJDat1xDWRwVR6A=="
+      "integrity": "sha1-JGenZQepjGPONAcvmWX0Ak51Pfw="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1891,7 +1891,7 @@
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4="
     },
     "charenc": {
       "version": "0.0.2",
@@ -1962,7 +1962,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -2006,7 +2006,7 @@
     "clear": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/clear/-/clear-0.1.0.tgz",
-      "integrity": "sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw=="
+      "integrity": "sha1-uBseA0N6cWmE/XrJfIfXO9/nBIo="
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -2218,7 +2218,7 @@
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -2230,7 +2230,7 @@
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -2499,7 +2499,7 @@
     "drange": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+      "integrity": "sha1-sq7Owqq4L87xHbvXueMrg/j2wLg="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -2513,7 +2513,7 @@
     "ecurve": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+      "integrity": "sha1-39q7txSfjYt4gWvlp9W4P89t55c=",
       "requires": {
         "bigi": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -3130,7 +3130,7 @@
     "external-editor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -3189,7 +3189,7 @@
     "figlet": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.2.1.tgz",
-      "integrity": "sha512-qc8gycfnnfOmfvPl7Fi3JeTbcvdmbZkckyUVGGAM02je7Ookvu+bBfKy1I4FKqTsQHCs3ARJ76ip/k98r+OQuQ=="
+      "integrity": "sha1-SNNd+dmxCxs4iDAubleQSgsAUJw="
     },
     "figures": {
       "version": "2.0.0",
@@ -3261,7 +3261,7 @@
     "flat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
       "requires": {
         "is-buffer": "~2.0.3"
       }
@@ -3348,8 +3348,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3370,14 +3369,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3392,20 +3389,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3522,8 +3516,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3535,7 +3528,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3550,7 +3542,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3558,14 +3549,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3584,7 +3573,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3665,8 +3653,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3678,7 +3665,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3764,8 +3750,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3801,7 +3786,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3821,7 +3805,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3865,14 +3848,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4230,7 +4211,7 @@
     "inquirer": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "integrity": "sha1-RpQRdvZcnrIIBGJxSbdDohjyVAY=",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -4250,12 +4231,12 @@
     "install": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/install/-/install-0.11.2.tgz",
-      "integrity": "sha512-vm3WeuqkmCK/jD56s7pWLKl4QoHMdcIwLlsMAFYV3XAbrz+RdyOJvtIQn/A1LiaNz2djUdwec01/90KLSIaUGg=="
+      "integrity": "sha1-ubcqVpgv87xnzajTgwGfRYtZpW4="
     },
     "interpret": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+      "integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY="
     },
     "invariant": {
       "version": "2.2.4",
@@ -4299,7 +4280,7 @@
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -5438,14 +5419,14 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         }
       }
     },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -5510,7 +5491,7 @@
     "merkle-tools": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/merkle-tools/-/merkle-tools-1.4.0.tgz",
-      "integrity": "sha512-OTLC8O1G68+CiNQ6H575XYODmTlOJEf4rDweWqoykA0CUOkyQQ7mS2pqLzN4i3kw5W+VqrHUflEWMrmNZ5OXYQ==",
+      "integrity": "sha1-bB0+t0sTCzCHPgQ0VPqYr+9C+wY=",
       "requires": {
         "js-sha3": "^0.5.7"
       }
@@ -9707,7 +9688,7 @@
     "randexp": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
-      "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
+      "integrity": "sha1-MnMmNY4ZDGhcIGnh+bRcUZDFF7I=",
       "requires": {
         "drange": "^1.0.0",
         "ret": "^0.2.0"
@@ -9741,7 +9722,7 @@
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -9829,8 +9810,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -10042,8 +10022,7 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
@@ -10100,8 +10079,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -10403,7 +10381,7 @@
     "ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+      "integrity": "sha1-toYXgqH0di3OQ0Aqcet6KD9EVzw="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -10417,7 +10395,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -10455,7 +10433,7 @@
     "rxjs": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "integrity": "sha1-87sP572n+2nerAwW8XtQsLh5BQQ=",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -10845,7 +10823,7 @@
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -10876,7 +10854,7 @@
     "shelljs": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "integrity": "sha1-p/MxlSDr8J7oEnWyNorbKGZZsJc=",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -10914,8 +10892,8 @@
       "dev": true
     },
     "sjcl": {
-      "version": "https://github.com/bitwiseshiftleft/sjcl/tarball/1.0.8",
-      "integrity": "sha512-pAu/nlu473LwXHu3lv4G5Pf+ja56/88l/Q/SJTjLXH5KLv7qNzOhw6LuLfHJtN+ZkNBXyhUMjrnHnN/ZJu2xqg=="
+      "version": "github:civicteam/sjcl#74fcc71a486a41d39200767d9235f6eac9e51f26",
+      "from": "github:civicteam/sjcl#v1.0.8-ecc"
     },
     "slash": {
       "version": "1.0.0",
@@ -11454,7 +11432,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -11492,7 +11470,7 @@
     "typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+      "integrity": "sha1-10FqLFhF4IUDTXD8xbbMSpDtv9w="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -11675,7 +11653,7 @@
     "varuint-bitcoin": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "integrity": "sha1-ejQ/UFN2B69qMFkxK5eCoXCJRUA=",
       "requires": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "pretag": "git fetch --tags",
     "tag": "git tag v$npm_package_version && git push origin --tags",
     "release:create": "hub release create -m v$npm_package_version v$npm_package_version",
-    "check": "npm run lint && npm run test",
-    "build-sjcl": "cd node_modules/sjcl && ./configure --with-ecc && make sjcl.js",
-    "postinstall": "npm run build-sjcl"
+    "check": "npm run lint && npm run test"
   },
   "devDependencies": {
     "ajv": "^6.5.2",
@@ -58,7 +56,7 @@
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "sift": "^6.0.0",
-    "sjcl": "https://github.com/bitwiseshiftleft/sjcl/tarball/1.0.8",
+    "sjcl": "github:civicteam/sjcl#v1.0.8-ecc",
     "type-of-is": "^3.5.1",
     "winston": "^3.2.0"
   },


### PR DESCRIPTION
DSR requires a pre-built version of [sjcl](https://github.com/bitwiseshiftleft/sjcl) with support to ECC curves (for more details, refer to: https://github.com/bitwiseshiftleft/sjcl/wiki/Getting-Started).

The *sjcl* library with ECC support was being built after the dependencies installation (by a *postinstall* hook). As the build process of *sjcl* library requires the *Java RE* to be installed, we decided to replace it by a pre-built fork of the library on https://github.com/civicteam/sjcl.

***Java RE* is no longer a dependency of DSR.**
  