### PR TITLE
Checks if credentialsMatchesRequest(credentialItems, request) params

### DIFF
--- a/src/ScopeRequest.js
+++ b/src/ScopeRequest.js
@@ -45,6 +45,13 @@ class ScopeRequest {
   static credentialsMatchesRequest(credentialItems, request) {
     let result = true;
     const requestedItems = _.get(request, 'credentialItems');
+
+    if (_.isEmpty(requestedItems)) {
+      throw new Error('invalid scopeRequest object');
+    }
+    if (_.isEmpty(credentialItems)) {
+      throw new Error('empty credentialItems param');
+    }
     // eslint-disable-next-line consistent-return
     _.forEach(requestedItems, (requestedItem) => {
       const credentialItem = _.find(credentialItems, { identifier: requestedItem.identifier });

--- a/test/unit/ScopeRequest.test.js
+++ b/test/unit/ScopeRequest.test.js
@@ -687,6 +687,41 @@ describe('DSR Request Utils', () => {
     const match = ScopeRequest.credentialsMatchesRequest(credentialItems, dsr);
     expect(match).toBeFalsy();
   });
+
+  it('Should throw with empty credentialItems', () => {
+    const credentialItems = []; // This is should be the CI on the scopeRequest response
+    const dsr = new ScopeRequest('abcd',
+      [{
+        identifier: 'credential-cvc:IdDocument-v1',
+        constraints: {
+          meta: {
+            issuer: { is: { $eq: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74' } },
+          },
+          claims: [
+            { path: 'document.dateOfBirth', is: { $lte: '-45y' } },
+          ],
+        },
+      }]);
+    expect(dsr).toBeDefined();
+    expect(() => ScopeRequest.credentialsMatchesRequest(credentialItems, dsr)).toThrow('empty credentialItems param');
+  });
+
+  it('Should throw with invaid scopeRequest', () => {
+    const credentialItems = [idDoc]; // This is should be the CI on the scopeRequest response
+    const dsr = [{
+      identifier: 'credential-cvc:IdDocument-v1',
+      constraints: {
+        meta: {
+          issuer: { is: { $eq: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74' } },
+        },
+        claims: [
+          { path: 'document.dateOfBirth', is: { $lte: '-45y' } },
+        ],
+      },
+    }];
+    expect(dsr).toBeDefined();
+    expect(() => ScopeRequest.credentialsMatchesRequest(credentialItems, dsr)).toThrow('invalid scopeRequest object');
+  });
 });
 
 module.exports = ScopeRequest;


### PR DESCRIPTION
credentialsMatchesRequest(credentialItems, request) was returning `true` by default. With these changes, if the params are not valid the function will throw an error. 