### PR TITLE
Update scope request schema to include an ID

### DIFF
--- a/schemas/ScopeRequest/v1/Unresolved.json
+++ b/schemas/ScopeRequest/v1/Unresolved.json
@@ -13,6 +13,16 @@
     "channels"
   ],
   "properties": {
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The Id Schema",
+      "default": "",
+      "examples": [
+        "5121c5b1-1b1f-10c8-4a74-173f2f81"
+      ],
+      "pattern": "^(.*)$"
+    },
     "version": {
       "$id": "#/properties/version",
       "type": "string",

--- a/schemas/public/ScopeRequest/v1/Unresolved.json
+++ b/schemas/public/ScopeRequest/v1/Unresolved.json
@@ -1,106 +1,228 @@
 {
+  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "civ:ScopeRequest:Unresolved",
+  "$id": "http://example.com/root.json",
   "type": "object",
+  "title": "civ:ScopeRequest:Unresolved",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "requesterInfo",
+    "timestamp",
+    "credentialItems",
+    "channels"
+  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The Id Schema",
+      "default": "",
+      "examples": [
+        "5121c5b1-1b1f-10c8-4a74-173f2f81"
+      ],
+      "pattern": "^(.*)$"
     },
-    "timestamp": {
-      "type": "string"
+    "version": {
+      "$id": "#/properties/version",
+      "type": "string",
+      "title": "The Version Schema",
+      "default": "",
+      "examples": [
+        "1"
+      ],
+      "pattern": "^(.*)$"
     },
     "requesterInfo": {
+      "$id": "#/properties/requesterInfo",
       "type": "object",
+      "title": "The Requesterinfo Schema",
+      "required": [
+        "app",
+        "requesterId"
+      ],
       "properties": {
-        "requesterId": {
-          "type": "string"
-        },
         "app": {
+          "$id": "#/properties/requesterInfo/properties/app",
           "type": "object",
+          "title": "The App Schema",
+          "required": [
+            "description",
+            "id",
+            "name",
+            "logo",
+            "primaryColor",
+            "secondaryColor"
+          ],
           "properties": {
+            "description": {
+              "$id": "#/properties/requesterInfo/properties/app/properties/description",
+              "type": "string",
+              "title": "The Description Schema",
+              "default": "",
+              "examples": [
+                "Case 13: To test resolveMissingCredentials()"
+              ],
+              "pattern": "^(.*)$"
+            },
             "id": {
-              "type": "string"
+              "$id": "#/properties/requesterInfo/properties/app/properties/id",
+              "type": "string",
+              "title": "The Id Schema",
+              "default": "",
+              "examples": [
+                "7107a5b4-8a1f-11e8-9a94-37352f73"
+              ],
+              "pattern": "^(.*)$"
             },
             "name": {
-              "type": "string"
+              "$id": "#/properties/requesterInfo/properties/app/properties/name",
+              "type": "string",
+              "title": "The Name Schema",
+              "default": "",
+              "examples": [
+                "My Awesome Identity.com Integration"
+              ],
+              "pattern": "^(.*)$"
             },
             "logo": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
+              "$id": "#/properties/requesterInfo/properties/app/properties/logo",
+              "type": "string",
+              "title": "The Logo Schema",
+              "default": "",
+              "examples": [
+                "https://upload.wikimedia.org/wikipedia/commons/5/5f/Atletico_mineiro_galo.png"
+              ],
+              "pattern": "^(.*)$"
             },
             "primaryColor": {
-              "type": "string"
+              "$id": "#/properties/requesterInfo/properties/app/properties/primaryColor",
+              "type": "string",
+              "title": "The Primarycolor Schema",
+              "default": "",
+              "examples": [
+                "ffffff"
+              ],
+              "pattern": "^(.*)$"
             },
             "secondaryColor": {
-              "type": "string"
+              "$id": "#/properties/requesterInfo/properties/app/properties/secondaryColor",
+              "type": "string",
+              "title": "The Secondarycolor Schema",
+              "default": "",
+              "examples": [
+                "000000"
+              ],
+              "pattern": "^(.*)$"
             }
           }
+        },
+        "requesterId": {
+          "$id": "#/properties/requesterInfo/properties/requesterId",
+          "type": "string",
+          "title": "The Requesterid Schema",
+          "default": "",
+          "examples": [
+            "3735a5b4-8a1f-11e8-9a94-a6cf71072f73"
+          ],
+          "pattern": "^(.*)$"
         }
       }
     },
-    "channels": {
-      "type": "object",
-      "properties": {
-        "eventsURL": {
-          "type": "string"
-        },
-        "payloadURL": {
-          "type": "string"
-        }
-      }
+    "timestamp": {
+      "$id": "#/properties/timestamp",
+      "type": "string",
+      "title": "The Timestamp Schema",
+      "default": "",
+      "examples": [
+        "2018-11-20T11:51:59.188Z"
+      ],
+      "pattern": "^(.*)$"
     },
     "credentialItems": {
+      "$id": "#/properties/credentialItems",
       "type": "array",
+      "title": "The Credentialitems Schema",
       "items": {
-        "anyOf": [
-          {
-            "type": "string"
+        "$id": "#/properties/credentialItems/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "identifier"
+        ],
+        "properties": {
+          "identifier": {
+            "$id": "#/properties/credentialItems/items/properties/identifier",
+            "type": "string",
+            "title": "The Identifier Schema",
+            "default": "",
+            "examples": [
+              "credential-cvc:Identity-v1"
+            ],
+            "pattern": "^(.*)$"
           },
-          {
+          "constraints": {
+            "$id": "#/properties/credentialItems/items/properties/constraints",
             "type": "object",
-            "identifier": {
-              "type": "string"
-            },
-            "constraints": {
-              "type": "object",
-              "properties": {
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "issuer": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "issued": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "expiry": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  }
-                },
-                "claims": {
-                  "type": "array",
-                  "items": {
+            "title": "The Constraints Schema",
+            "required": [
+              "meta"
+            ],
+            "properties": {
+              "meta": {
+                "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta",
+                "type": "object",
+                "title": "The Meta Schema",
+                "required": [
+                  "credential",
+                  "issuer"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "noClaims": {
+                    "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta/properties/emptyClaim",
+                    "type": "boolean",
+                    "title": "The flag that allows to ask for no claims in the DSR only validating if the claim exists",
+                    "examples": [
+                      "true or false"
+                    ]
+                  },
+                  "credential": {
+                    "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta/properties/credential",
+                    "type": "string",
+                    "title": "The Credential Version defined on Credential Commons project and in the Marketplace",
+                    "default": "",
+                    "examples": [
+                      "credential-cvc:Identity-v1"
+                    ],
+                    "pattern": "^(.*)$"
+                  },
+                  "issuer": {
+                    "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta/properties/issuer",
                     "type": "object",
-                    "path": {
-                      "type": "string"
-                    },
-                    "is": {
-                      "type": "object",
-                      "properties": {
-                        "property": {
-                          "type": "string"
+                    "title": "The Issuer Schema",
+                    "required": [
+                      "is"
+                    ],
+                    "properties": {
+                      "is": {
+                        "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta/properties/issuer/properties/is",
+                        "type": "object",
+                        "title": "The Is Schema",
+                        "required": [
+                          "$eq"
+                        ],
+                        "properties": {
+                          "$eq": {
+                            "$id": "#/properties/credentialItems/items/properties/constraints/properties/meta/properties/issuer/properties/is/properties/$eq",
+                            "type": "string",
+                            "title": "The $eq Schema",
+                            "default": "",
+                            "examples": [
+                              "did:ethr:0x1a88a35421a4a0d3e13fe4e8ebcf18e9a249dc5a"
+                            ],
+                            "pattern": "^(.*)$"
+                          }
                         }
                       }
                     }
@@ -109,31 +231,39 @@
               }
             }
           }
-        ]
-      }
-    },
-    "constraints": {
-      "type": "object",
-      "properties": {
-        "min-budget": {
-          "type": "number"
-        },
-        "max-budget": {
-          "type": "number"
-        },
-        "required-stake": {
-          "type": "number"
         }
       }
     },
-    "authorization": {
+    "channels": {
+      "$id": "#/properties/channels",
       "type": "object",
+      "title": "The Channels Schema",
+      "required": [
+        "eventsURL",
+        "payloadURL"
+      ],
       "properties": {
-        "jwt": {
-          "type": "string"
+        "eventsURL": {
+          "$id": "#/properties/channels/properties/eventsURL",
+          "type": "string",
+          "title": "The Eventsurl Schema",
+          "default": "",
+          "examples": [
+            "https://awesome-idr.com/response/events"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "payloadURL": {
+          "$id": "#/properties/channels/properties/payloadURL",
+          "type": "string",
+          "title": "The Payloadurl Schema",
+          "default": "",
+          "examples": [
+            "https://awesome-idr.com/response/payload"
+          ],
+          "pattern": "^(.*)$"
         }
       }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/test/fixtures/simpleUnresolvedRequest.json
+++ b/test/fixtures/simpleUnresolvedRequest.json
@@ -1,4 +1,5 @@
 {
+  "id": "AUniqId?",
   "version": "1",
   "timestamp": "2018-07-04T00:11:55.698Z",
   "requesterInfo": {


### PR DESCRIPTION
The schema for Scope Request was updated to allow an `id` attribute to be optionally included in a Scope Requests, as follows:
``` 
{
  "id": "AUniqId?",
  "version": "1",
  "timestamp": "2018-07-04T00:11:55.698Z",
  "requesterInfo": {
    ...
    }
  },
  "channels": {
    ...
  },
  "credentialItems": [
    ...
  ]
}
```