### PR TITLE
Add authentication flag to scope request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
       }
     },
     "@identity.com/credential-commons": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@identity.com/credential-commons/-/credential-commons-1.0.25.tgz",
-      "integrity": "sha512-X9TWxSM0lczuOCIEnh3YJeiNGxOBw38bk4yX4dHfPMUUOE+/Ue+uy9P3kK9wPI2hX+XYe8qYJkJm3UIeuO91Xw==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@identity.com/credential-commons/-/credential-commons-1.0.26.tgz",
+      "integrity": "sha512-A1JS3x8rzMbeeIZa/D21AfkmY6iw1OVJez45iyQX50+5beEwxYK8OIyv9RstDosE5EPkEoZ4rpFmD7bx+yTs0A==",
       "requires": {
         "@identity.com/uca": "1.0.14",
         "ajv": "^6.10.2",
@@ -292,11 +292,6 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "node-fetch": {
           "version": "2.6.0",
@@ -1442,7 +1437,8 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-parser": {
       "version": "3.2.9",
@@ -1453,7 +1449,8 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -3084,6 +3081,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -4257,6 +4255,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -5307,29 +5306,95 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+      "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
       "requires": {
-        "ansi-escapes": "^3.2.0",
+        "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
+        "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
         }
       }
     },
@@ -5470,7 +5535,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -7773,7 +7839,8 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7837,7 +7904,8 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "nan": {
       "version": "2.13.2",
@@ -8136,6 +8204,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -9279,6 +9348,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -10083,6 +10153,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -10092,6 +10163,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -10361,6 +10433,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
     },
     "type-of-is": {
       "version": "3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/dsr",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3519,9 +3519,9 @@
       }
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
     "diff-sequences": {
@@ -3531,14 +3531,14 @@
       "dev": true
     },
     "diff2html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.7.0.tgz",
-      "integrity": "sha512-xaVsOea1ONo4lYIXd4G+pBLZ6RDkSM82My7irpuwXYK1WymbVdHgmWkBUGJKZyTyJhDHM3E30ml1nSOl5AyyEQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.11.2.tgz",
+      "integrity": "sha512-FKDFFXW0cHyt+joiYeyWxbcLWZsQYeYRRrHKWZEvu+XMFMM1ChxTkGhET53zAU0tvVjyRRxRjUcrn5ImSqD0ZQ==",
       "dev": true,
       "requires": {
-        "diff": "^3.5.0",
+        "diff": "^4.0.1",
         "hogan.js": "^3.0.2",
-        "lodash.merge": "^4.6.1",
+        "merge": "^1.2.1",
         "whatwg-fetch": "^3.0.0"
       }
     },
@@ -7143,21 +7143,21 @@
       }
     },
     "jest-stare": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-1.13.2.tgz",
-      "integrity": "sha512-R64MLXoR0j0B8QC8NMto5bfbaHMzzfVKECCzyvBtFJsMq1d6UgkcBsqQkWY9tXIrBMWxQ8VgomMooV9OJpeYGA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-1.18.1.tgz",
+      "integrity": "sha512-oUc0n5A2Q/gu942aHvXoOK/e0pI4XWSZgq2oKLY/LV9rVIuP/eRd+VbWIllIFB6wFYUe5lwQXlo8wS4Iqjxruw==",
       "dev": true,
       "requires": {
         "ansi-parser": "^3.2.9",
-        "bootstrap": "^4.2.1",
+        "bootstrap": "^4.3.1",
         "chalk": "^2.4.2",
         "chart.js": "^2.7.3",
-        "diff2html": "^2.7.0",
+        "diff2html": "^2.9.0",
         "holderjs": "^2.9.6",
-        "jquery": "^3.2.1",
+        "jquery": "^3.4.1",
         "moment": "^2.23.0",
-        "mustache": "^2.3.2",
-        "pkg-up": "^2.0.0",
+        "mustache": "^3.0.0",
+        "pkg-up": "^3.0.0",
         "popper.js": "^1.14.6"
       }
     },
@@ -7260,9 +7260,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
     "js-sha3": {
@@ -7526,20 +7526,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.some": {
@@ -7688,6 +7682,12 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -7829,9 +7829,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mustache": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==",
       "dev": true
     },
     "mute-stream": {
@@ -8399,12 +8399,57 @@
       }
     },
     "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
       }
     },
     "pluralize": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/dsr",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "The Dynamic Scope Request (DSR) javascript library provides capability around securely requesting credential information between an ID Requester and an ID Holder",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-no-only-tests": "^2.0.1",
     "eslint-plugin-react": "^7.10.0",
     "jest": "^24.8.0",
-    "jest-stare": "^1.13.0",
+    "jest-stare": "^1.18.1",
     "node-fetch": "^2.1.2",
     "request-debug": "^0.2.0",
     "rimraf": "^2.6.2"
@@ -53,7 +53,7 @@
     "bottlejs": "^1.7.1",
     "dotenv": "^6.0.0",
     "json-stable-stringify": "^1.0.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
     "sift": "^6.0.0",
     "sjcl": "github:civicteam/sjcl#v1.0.8-ecc",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@identity.com/credential-commons": "^1.0.25",
+    "@identity.com/credential-commons": "^1.0.26",
     "@identity.com/uca": "^1.0.14",
     "bottlejs": "^1.7.1",
     "dotenv": "^6.0.0",

--- a/schemas/ScopeRequest/v1/Unresolved.json
+++ b/schemas/ScopeRequest/v1/Unresolved.json
@@ -9,6 +9,7 @@
     "version",
     "requesterInfo",
     "timestamp",
+    "authentication",
     "credentialItems",
     "channels"
   ],
@@ -138,6 +139,15 @@
         "2018-11-20T11:51:59.188Z"
       ],
       "pattern": "^(.*)$"
+    },
+    "authentication": {
+      "$id": "#/properties/authentication",
+      "type": "boolean",
+      "title": "The flag that specifies if authentication is required",
+      "default": "true",
+      "examples": [
+        "true or false"
+      ]
     },
     "credentialItems": {
       "$id": "#/properties/credentialItems",

--- a/schemas/public/ScopeRequest/v1/Unresolved.json
+++ b/schemas/public/ScopeRequest/v1/Unresolved.json
@@ -9,6 +9,7 @@
     "version",
     "requesterInfo",
     "timestamp",
+    "authentication",
     "credentialItems",
     "channels"
   ],
@@ -138,6 +139,15 @@
         "2018-11-20T11:51:59.188Z"
       ],
       "pattern": "^(.*)$"
+    },
+    "authentication": {
+      "$id": "#/properties/authentication",
+      "type": "boolean",
+      "title": "The flag that specifies if authentication is required",
+      "default": "true",
+      "examples": [
+        "true or false"
+      ]
     },
     "credentialItems": {
       "$id": "#/properties/credentialItems",

--- a/src/ScopeRequest.js
+++ b/src/ScopeRequest.js
@@ -260,17 +260,28 @@ class ScopeRequest {
     return true;
   }
 
-  constructor(uniqueId, requestedItems, channelsConfig, appConfig, partnerConfig) {
+  static validateAuthentication(authentication) {
+    if (!_.isBoolean(authentication)) {
+      throw new Error('Invalid value for authentication');
+    }
+    return true;
+  }
+
+  constructor(uniqueId, requestedItems, channelsConfig, appConfig, partnerConfig, authentication = true) {
     this.version = SCHEMA_VERSION;
     if (!uniqueId) {
       throw Error('uniqueId is required');
     }
     this.id = uniqueId;
     this.requesterInfo = {};
+
+    if (ScopeRequest.validateAuthentication(authentication)) {
+      this.authentication = authentication;
+    }
+
     this.timestamp = (new Date()).toISOString();
 
     const credentialItems = [].concat(requestedItems);
-
     if (ScopeRequest.validateCredentialItems(credentialItems)) {
       this.credentialItems = _.cloneDeep(credentialItems);
     }

--- a/test/fixtures/complexUnresolvedRequest.json
+++ b/test/fixtures/complexUnresolvedRequest.json
@@ -1,26 +1,28 @@
 {
   "version": "1",
+  "id": "AUniqId?",
   "requesterInfo": {
     "app": {
-      "description": "Case 13: To test resolveMissingCredentials()",
-      "id": "7107a5b4-8a1f-11e8-9a94-37352f73",
-      "name": "My Awesome Identity.com Integration",
-      "logo": "https://upload.wikimedia.org/wikipedia/commons/5/5f/Atletico_mineiro_galo.png",
-      "primaryColor": "ffffff",
-      "secondaryColor": "000000"
+      "description": "NA",
+      "id": "pNCIYblwy",
+      "name": "Thundercats",
+      "logo": "https://s3.amazonaws.com/dev-integration-portal-app-logos/kx3VTykbN/1548405721-thundercats.jpeg",
+      "primaryColor": "#A80B00",
+      "secondaryColor": "#000000"
     },
     "requesterId": "3735a5b4-8a1f-11e8-9a94-a6cf71072f73"
   },
-  "timestamp": "2018-11-20T11:51:59.188Z",
+  "timestamp": "2019-08-01T19:16:39.336Z",
+  "authentication": true,
   "credentialItems": [
     {
-      "identifier": "credential-cvc:Identity-v1",
+      "identifier": "credential-cvc:IdDocument-v2",
       "constraints": {
         "meta": {
-          "credential": "credential-cvc:Identity-v1",
+          "credential": "credential-cvc:IdDocument-v2",
           "issuer": {
             "is": {
-              "$eq": "did:ethr:0xaf9482c84De4e2a961B98176C9f295F9b6008BfD"
+              "$eq": "did:ethr:0x1a88a35421a4a0d3e13fe4e8ebcf18e9a249dc5a"
             }
           }
         }
@@ -28,6 +30,23 @@
     }
   ],
   "channels": {
+    "evidences": {
+      "idDocumentFront": {
+        "accepts": "application/json",
+        "method": "put",
+        "url": "https://put-url.com"
+      },
+      "idDocumentBack": {
+        "accepts": "application/json",
+        "method": "put",
+        "url": "https://put-url.com"
+      },
+      "selfie": {
+        "accepts": "application/json",
+        "method": "put",
+        "url": "https://put-url.com"
+      }
+    },
     "eventsURL": "https://awesome-idr.com/response/events",
     "payloadURL": "https://awesome-idr.com/response/payload"
   }

--- a/test/fixtures/simpleUnresolvedRequest.json
+++ b/test/fixtures/simpleUnresolvedRequest.json
@@ -1,7 +1,6 @@
 {
   "id": "AUniqId?",
   "version": "1",
-  "timestamp": "2018-07-04T00:11:55.698Z",
   "requesterInfo": {
     "requesterId": "uuid",
     "app": {
@@ -13,6 +12,8 @@
       "secondaryColor": "2345FF"
     }
   },
+  "timestamp": "2018-07-04T00:11:55.698Z",
+  "authentication": true,
   "channels": {
     "eventsURL": "https://server/events/UUID",
     "payloadURL": "https://server/payload/UUID"


### PR DESCRIPTION
Add authentication flag in scope request to specify if authentication is required or not.

`authentication` is a boolean property that can be specified in the _ScopeRequest_ constructor:
```
const authentication = false;
const dsr = new ScopeRequest(id, requestedItems, channels, appConfig, partnerConfig, authentication);
```
`authentication` is mandatory within the DSR schema, but it's optional in the _ScopeRequest_ constructor (default to true).

Example of a DSR with `authentication`:
```
{
  "version": "1",
  "id": "abc",
  "requesterInfo": {
    "app": {
      "description": "Example",
      "id": "xyz",
      "name": "Test",
      "logo": "testlogo.com",
      "primaryColor": "#FF",
      "secondaryColor": "#FF"
    },
    "requesterId": "123abc"
  },
  "timestamp": "2019-08-01T19:16:39.336Z",
  "authentication": true,
  "credentialItems": [
    {
      "identifier": "credential-cvc:IdDocument-v2",
      "constraints": {
        "meta": {
          "credential": "credential-cvc:IdDocument-v2",
          "issuer": {
            "is": {
              "$eq": "did:ethr:0x1b66a25411c3a0d1a13fe4a8ebdf18e9a249ac3f"
            }
          }
        }
      }
    }
  ],
  "channels": {
    "eventsURL": "https://awesome-idr.com/response/events",
    "payloadURL": "https://awesome-idr.com/response/payload"
  }
}
```

This PR also updates `jest` and `lodash` to fix vulnerabilities.